### PR TITLE
Fix tokenizer and env handling bugs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ NAME = hsh
 .PHONY: all clean oclean fclean re
 
 all: shell_2.h $(OBJ)
-	$(CC) $(OBJ) -o $(NAME)
+	$(CC) $(OBJ) -o $(NAME) -no-pie
 
 clean:
 	$(RM) *~ $(NAME)

--- a/env.c
+++ b/env.c
@@ -77,32 +77,21 @@ char **env_array(char *cmd, char **environ)
  */
 char *_getenv(char *name, char **environ)
 {
-	char *env_var, *name_cpy;
-	unsigned int i = 0, len;
+        unsigned int i;
+        size_t len;
 
-	len = _strlen(name);
-	name_cpy = malloc((sizeof(char) * len) + 1);
-	if (!name_cpy)
-		return (NULL);
+        if (!name || !environ)
+                return (NULL);
 
-	_strncpy(name_cpy, name, len);
-	env_var = strtok(environ[i], "=");
+        len = _strlen(name);
 
-	while (environ[i])
-	{
-		if (_strcmp(env_var, name_cpy) == 0)
-		{
-			env_var = strtok(NULL, "\n");
-			free(name_cpy);
-			name_cpy = NULL;
-			return (env_var);
-		}
-		i++;
-		env_var = strtok(environ[i], "=");
-	}
-	free(name_cpy);
-	name_cpy = NULL;
-	return (NULL);
+        for (i = 0; environ[i]; i++)
+        {
+                if (strncmp(environ[i], name, len) == 0 && environ[i][len] == '=')
+                        return (environ[i] + len + 1);
+        }
+
+        return (NULL);
 }
 /**
  * _printenv - prints out env in full
@@ -110,15 +99,18 @@ char *_getenv(char *name, char **environ)
  */
 void _printenv(char **env)
 {
-	unsigned int i, len;
+        unsigned int i = 0, len;
 
-	while (env[i])
-	{
-		len = _strlen(env[i]);
-		write(1, env[i], len);
-		write(1, "\n", 1);
-		i++;
-	}
+        if (!env)
+                return;
+
+        while (env[i])
+        {
+                len = _strlen(env[i]);
+                write(1, env[i], len);
+                write(1, "\n", 1);
+                i++;
+        }
 }
 /**
  * exec_env - executes on env builtin call

--- a/get_tokens.c
+++ b/get_tokens.c
@@ -9,44 +9,59 @@
  */
 int get_tokens(char *line, const char *delimiters, char ***argvp)
 {
-	int error, i, numtokens = 0;
-	char *t;
-	const char *snew;
+        int error, i, numtokens = 0;
+        char *t, *token, *line_cpy;
+        const char *snew;
 
-	line[_strlen(line) - 1] = '\0';
-	if ((line == NULL) || (delimiters == NULL) || (argvp == NULL))
-	{
-		errno = EINVAL;
-		return (-1);
-	}
-	*argvp = NULL;
-	snew = line + _strspn(line, delimiters);
-	t = malloc(_strlen(snew) + 1);
-	if (t == NULL)
-		return (-1);
-	_strcpy(t, snew);
-	if (strtok(t, delimiters) != NULL)
-		for (numtokens = 1; strtok(NULL, delimiters) != NULL; numtokens++)
-			;
-	*argvp = malloc((numtokens + 1) * sizeof(char *));
-	if (*argvp == NULL)
-	{
-		error = errno;
-		free(t);
-		t = NULL;
-		errno = error;
-		return (-1);
-	}
-	if (numtokens == 0)
-		free(t);
-	else
-	{
-		_strcpy(t, snew);
-		**argvp = strtok(t, delimiters);
-		for (i = 1; i < numtokens; i++)
-			*((*argvp) + i) = strtok(NULL, delimiters);
-	}
-	*((argvp) + numtokens) = NULL;
-	return (numtokens);
+        if (!line || !delimiters || !argvp)
+        {
+                errno = EINVAL;
+                return (-1);
+        }
+
+        if (_strlen(line) > 0 && line[_strlen(line) - 1] == '\n')
+                line[_strlen(line) - 1] = '\0';
+
+        *argvp = NULL;
+        snew = line + _strspn(line, delimiters);
+        line_cpy = malloc(_strlen(snew) + 1);
+        if (!line_cpy)
+                return (-1);
+        _strcpy(line_cpy, snew);
+
+        t = strtok(line_cpy, delimiters);
+        while (t)
+        {
+                numtokens++;
+                t = strtok(NULL, delimiters);
+        }
+
+        *argvp = malloc((numtokens + 1) * sizeof(char *));
+        if (*argvp == NULL)
+        {
+                error = errno;
+                free(line_cpy);
+                errno = error;
+                return (-1);
+        }
+
+        _strcpy(line_cpy, snew);
+        token = strtok(line_cpy, delimiters);
+        for (i = 0; token; i++)
+        {
+                (*argvp)[i] = malloc(_strlen(token) + 1);
+                if (!(*argvp)[i])
+                {
+                        free(line_cpy);
+                        free_dub(*argvp);
+                        return (-1);
+                }
+                _strcpy((*argvp)[i], token);
+                token = strtok(NULL, delimiters);
+        }
+        (*argvp)[i] = NULL;
+
+        free(line_cpy);
+        return (numtokens);
 }
 

--- a/main.c
+++ b/main.c
@@ -38,7 +38,7 @@ char *read_line(void)
 int main(int ac, char **av, char **env)
 {
 	char *line;
-	int status = 1, count;
+        int status = 1, count = 0;
 	(void)ac;
 
 	signal(SIGINT, exec_sig);

--- a/util.c
+++ b/util.c
@@ -6,23 +6,18 @@
  */
 void free_dub(char **dub)
 {
-	unsigned int i = 0;
+        unsigned int i = 0;
 
-	if (!dub)
-		return;
-	while (dub[i])
-	{
-		free(dub);
-		dub = NULL;
-		i++;
-	}
-	if (dub[i] == NULL)
-	{
-		free(dub[i]);
-		dub[i] = NULL;
-	}
+        if (!dub)
+                return;
 
-	free(dub);
-	dub = NULL;
+        while (dub[i])
+        {
+                free(dub[i]);
+                dub[i] = NULL;
+                i++;
+        }
+
+        free(dub);
 }
 


### PR DESCRIPTION
## Summary
- allocate and copy tokens individually
- fix `_getenv` to avoid modifying environment
- initialize variables and correct `free_dub`
- ensure environment printing starts from index 0
- use `-no-pie` when linking

## Testing
- `make`
- `echo 'env
exit' | ./hsh | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_684cca58d0f8832eb562be47b2aa16dc